### PR TITLE
Remove default verbose flag for shadowsocks-libev

### DIFF
--- a/shadowsocks-libev
+++ b/shadowsocks-libev
@@ -71,7 +71,7 @@ do_start() {
         echo "$NAME (pid $PID) is already running..."
         return 0
     fi
-    $DAEMON -v -c $CONF -f $PID_FILE
+    $DAEMON -c $CONF -f $PID_FILE
     if check_running; then
         echo "Starting $NAME success"
     else


### PR DESCRIPTION
Removed default -v (verbose) flag for shadowsocks-libev since it's only needed for debug.