### PR TITLE
Fix Python package installation on Debian-based systems

### DIFF
--- a/shadowsocks.sh
+++ b/shadowsocks.sh
@@ -308,7 +308,7 @@ install_dependencies() {
     elif check_sys packageManager apt; then
         apt_depends=(
             autoconf automake build-essential cpio curl gcc gettext git gzip libpcre3 libpcre3-dev
-            libtool make openssl perl python python-dev python-setuptools qrencode unzip
+            libtool make openssl perl python3 qrencode unzip
             libc-ares-dev libev-dev libssl-dev zlib1g-dev
         )
 


### PR DESCRIPTION
Fixed a bug on Debian-based systems where a script tries to install python packages (apt install python2 python-setuptools python-dev) that do not exist. THE SCRIPT HAS BEEN TESTED ON THE LATEST VERSION OF UBUNTU AND DEBIAN, THERE MAY BE ISSUES ON OLDER VERSIONS OF THE SYSTEM.